### PR TITLE
Add phase-based strategy

### DIFF
--- a/stage_based.md
+++ b/stage_based.md
@@ -41,7 +41,7 @@ switch: :main
   - `groups`: List of signal groups that are open (green).
   - `duration`: Default duration in seconds.
   - `min`/`max`: Optional minimum/maximum durations when shortening or extending the stage.
-- **order**:  sequence to run stages in.
+- **order**: Sequence to run stages in.
 - **switch**: Where a program switch is allowed. Switch happens at the beginning of the stage.
 
 The above program can be visualized like this:
@@ -56,14 +56,14 @@ switch |*         |  |     |  |         |  |
        0s                                  60s
 ```
 
-Interstage are indicated with ".." and does not show group states because they are determined by the controller at run time.
+Interstages are indicated with ".." and do not show group states because they are determined by the controller at run time.
 
 ## Stages
 Each stage is defined by which groups are open and for how long. All other groups will be closed.
 
-Open  typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bare for public transport.
+Open typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bar for public transport.
 
-All groups remain in the same state throughout the stage. All state changes happend during interstages.
+All groups remain in the same state throughout the stage. All state changes happen during interstages.
 
 You can define how much the stage can be shortened or extended, which will be used by the controller to adjust stage durations to ensure that the cycle time is respected.
 The controller will also extend and shorten stages when the offset needs to be moved.
@@ -80,26 +80,26 @@ A change in offset can happen for several reasons, e.g.:
 - synchronization of the underlying UTC time
 - leap seconds
 
-However, the offset cannot simply be abruptly changed, as this might cause invalid state changes, or might violate constrainst like minimum or inter-green times.
+However, the offset cannot simply be abruptly changed, as this might cause invalid state changes, or might violate constraints like minimum or inter-green times.
 
 Instead the desired offset must be reached as quickly as possible while respecting all constraints.
 
 ### Extending and Shortening Stages
 If the offset needs to move backward the controller can extend a stage up to the `max` set for the stage. If max is not set, the stage cannot be extended.
-Conversely, if the offset needs to move forward the controller can shorten a stage down to the `min` set of the stage. If min is not set, the stage cannot be shorted.
+Conversely, if the offset needs to move forward the controller can shorten a stage down to the `min` set for the stage. If min is not set, the stage cannot be shortened.
 
-Reaching the target offset will be typically be quicker if both min and max values are defines. If no minimum or maximum, values are defined, the controller canonot adjust the offset, and the program cannot be coordinated with other controllers.
+Reaching the target offset will typically be quicker if both min and max values are defined. If no minimum or maximum values are defined, the controller cannot adjust the offset, and the program cannot be coordinated with other controllers.
 
-Reaching the target offset might take more than one cycle, depending on the min/mx values defined.
+Reaching the target offset might take more than one cycle, depending on the min/max values defined.
 
 Once the target offset is reached, the controller must adjust stage durations to ensure that the cycle time matches the value defined in the program.
 
 
-### Proportial Offset Adjustment
-The controller must used the default, min and max durations defines for each stage to distribute an adjustment proportially across stages.
+### Proportional Offset Adjustment
+The controller must use the default, min and max durations defined for each stage to distribute an adjustment proportionally across stages.
 
 Possible extension is computed as: max - default
-Possible shortening is cmpute as: default - min.
+Possible shortening is computed as: default - min.
 
 In the program above, maximum shortenings and extensions are:
 
@@ -107,15 +107,15 @@ In the program above, maximum shortenings and extensions are:
 |--|--|--|
 |main||10s (66%)|
 |side|10s (100%)|5s (33%)|
-|turn||
+|turn|||
 
-The proportions are shown a percentages.
+The proportions are shown as percentages.
 
-If the offset must be moved back by 9s the `main` stage will be extend by 6s, while `side` will be extended by 3s. 
+If the offset must be moved back by 9s the `main` stage will be extended by 6s, while `side` will be extended by 3s. 
 After a single cycle, the offset target will be reached, and the stage will go back to durations that ensure that the cycle time is 60s (including interstages).
 
-If the offset must be moved back to 21s  the `main` stage needs to be extend by 14s, while `side` needs to be extended by 7s. But the max extensions must be respected, so in the first cycle,
- `main` will be extended by 10s, and `side` by 5s, which will move the offset back by 15s, leaving if 6s from the target. In the second cycle, the `main` stage will be extend by 4s and while `side` by 2s.
+If the offset must be moved back by 21s the `main` stage needs to be extended by 14s, while `side` needs to be extended by 7s. But the max extensions must be respected, so in the first cycle,
+ `main` will be extended by 10s, and `side` by 5s, which will move the offset back by 15s, leaving it 6s from the target. In the second cycle, the `main` stage will be extended by 4s and `side` by 2s.
 
 ## Switching Programs
 A program switch can occur only at the start of the stage defined in `switch`. Both the current and target programs must have compatible signal states at the switch point to ensure a safe transition.
@@ -123,9 +123,9 @@ A program switch can occur only at the start of the stage defined in `switch`. B
 It's allowed to switch between programs using different control strategies.
 
 When a switch is requested the controller continues until the switch point, then transitions to the switch point in the target program.
-A new target offset is determined, and the offset is grdually moved to the target, using the mechanism defined for tthe type of strategy of the targert program.
+A new target offset is determined, and the offset is gradually moved to the target, using the mechanism defined for the type of strategy of the target program.
 
 ## Failures
-The controller must respect all safety constraints (minimum green, intergreen, etc.). Invalid configurations or unsafe transitions results in a fault.
+The controller must respect all safety constraints (minimum green, intergreen, etc.). Invalid configurations or unsafe transitions result in a fault.
 Programs should be validated using a simulator or test tool before deployment.
 


### PR DESCRIPTION
Based on conversations, it might be useful to add a phase-based control strategy.

It has similarities to using smart states, because the controller determines all intermediate states- the interphase are automatically handled by the contoller. But it's different because you define phases, and how they are ordered.

You still have an offset for coordination and define waits and skips that the controller can use to adjust the offset. But skip means skipping a phase entirely. You can use define shortening, which shortens a phase, but doesn't skip it entirely.

In this draft you cannot define interphases; they are completely determined by the controller at run time. This does of course require that you have configured intergreen times, etc.

Replaces issue #30

View added file with Markdown formatting:
https://github.com/rsmp-nordic/tlc_programming/blob/8466c49cbfad447cf73ceb7deba08a06ba1f8c1b/phase_based.md