### PR TITLE
stage-based with explicit transitions

### DIFF
--- a/stage-based.md
+++ b/stage-based.md
@@ -1,5 +1,5 @@
 # Stage-based Strategy
-A stage-based program consists of stages separated by transitions.
+A stage-based program consists of stages separated by transitions. All state changes occur during transitions, while state state remain static during stages.
 
 ## Prerequisites
 Running a stage-based program depends on regional, controller, and intersection [configurations](configurations.md), which are defined outside the signal program.
@@ -40,18 +40,18 @@ stages:
 - **offset**: Default offset
 - **groups**: List of all signal groups
 - **stages**: Map of stages with stage name and options:
-  - `open`: List of signal groups that are open (green).
+  - `open`: List of signal groups that are open (typically green).
   - `duration`: Durations in seconds. `default` is required, while `min` and `max` are optional and specify possible shortening and extension.
   - `transitions`: Possible transitions. The key is the name of the stage to transition to, while the value is a transition map.
 
-A transition map define all state changes during the transation:
-  - keys: The transition time in seconds, measuring from the start of the transition. The first item must hve time 0.
-  - values: A string containing the state of all signal groups, with a character for each group, in the order defined in the 'groups' attribute.
+A transition map define all state changes during a transation:
+  - keys: Transition time in seconds, measured from the start of the transition.
+  - values: A string containing the state of all signal groups, with one character for each group, in the order defined in the 'groups' attribute.
 
-Transition maps must include one element with the value set to null/nil, whicb indicates the end (and thus the duration) of the transition. No other item can have a later time.
+Transition maps msut include one element with the tiem set to 0, representing the start of the transition.
+Transition maps must include one element with the value set to null/nil, which indicates the end of the transition. No  item can have times later than the end.
 
-
-In the program above, the `main` stage can transtion to either `side` or `turn`. Going through stages main-side-turn can be visualized as:
+In the program above, going through stages main-side-turn can be visualized as:
 
 ```
 stage  |main              |      |side             |   |turn    |   |
@@ -65,58 +65,60 @@ switch |*                 |      |                 |   |        |   |
 ```
 
 ## Stages
-Each stage is defined by which groups are open and for how long. All other groups will be closed.
+Each stage is defined by which groups are open and for how long. All other groups must be closed.
 
 Open typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bar for public transport.
 
-All groups remain in the same state throughout the stage. All state changes happen during interstages.
+All groups remain in the same state throughout the stage. All state changes happen during transitions.
 
-You can define how much the stage can be shortened or extended, which will be used by the controller to adjust stage durations to ensure that the cycle time is respected.
-The controller will also extend and shorten stages when the offset needs to be moved.
+You can define how much the stage can be shortened or extended by setting `min` and/or `max` durations.
 
-A transition defines hwo to move from one stage to another, by explicitely listing all states changes, including intermediate states like yellow.
-A transition does not include the start or end states, as these are defined by the stages you come from and go to.
+## Transitions
+A transition defines how to move from one stage to another by explicitely listing all states changes, including intermediate states like yellow.
 
-A particular transition always goes through the same state changes and always has the same duration.
+A transition does not include the start and end states, as these are defined by the stages you come from and go to.
+
+Transitions a fiex and goes through the same state changes every time, with the same duration.
 
 If a transition between stagess A and B is not defined, the program cannot transition directly from A to B, alhough it might be possible to reach B via other stages.
 
 When designing a stage-based program, it must be ensured that all transitions are valid.
 
 ## Changing Offset
-Intersections that use the same cycle length can be coordinated by modifying the offsets. But a change in offset can happen for other reasons, e.g.:
+Intersections that use the same cycle length can be coordinated by modifying their offsets. But a change in offset can happen for other reasons, e.g.:
 
 - manual change of the offset
 - change between signal programs
 - synchronization of the underlying UTC time
 - leap seconds
 
-However, the offset cannot simply be abruptly changed, as this might cause invalid state changes, or might violate constraints like minimum or inter-green times.
-Instead the offset must be moved by shortening of extending stages. Since all groups remain in the same state during a stage, this is guaranteed to never cause invalid state changes.
+However, the offset cannot be changed abruptly, as this might cause invalid state changes or might violate constraints like minimum or intergreen times.
+
+Instead the offset must be moved by shortening or/ extending stages. Since all groups remain in the same state during a stage, this is guaranteed to never cause invalid state changes.
 
 ### Extending and Shortening Stages
-To change the offset, stages must be shortened or extended. Shortening stages will move the offset forward, while extending stages will move the backward.
+Shortening stages will move the offset forward, while extending stages will move it backward.
 
-Since the program is cyclic, reaching the target offset can be achieved either by shorting or extending stages. The fastest way should be chosen.
+Since the program is cyclic, reaching the target offset can be achieved either by shorting or extending stages. The quickest way should be chosen.
 
-Only stages with `min` set can be shortened, and only stages with `max`set can be extended.
+Only stages with `min` defined can be shortened and only stages with `max` defined can be extended.
 
-Stages with neither `min`nor `max` are fixed in duration. If no `min`or `max` is set for any stage, the offset cannot be moved, and the controller cannot be coordinated with other controllers.
+Stages with neither `min` nor `max` are fixed in duration. If no stage defines a `min` or `max` the offset cannot be moved and the controller cannot be coordinated with other controllers.
 
-When trying to reach the taget offset, shortering/extending is done oen stage at a time, while respecting the min/max durations.  Reaching the target offset might take more than one cycle, depending on the min/max values defined.
+When trying to reach the target offset, shortening/extending is done one stage at a time, while respecting min/max durations. Reaching the target offset might take more than one cycle, depending on the min/max values defined and the target offset.
 
-Once the target offset is reached, the controller must adjust stage durations to ensure that the cycle time matches the value defined in the program, taking into account the interstage durations.
+Once the target offset is reached, the controller must adjust stage durations to ensure that the actual cycle time matches the cycle time defined in the program, taking into account the transition durations.
+
+A program is invalid if the stages cannot be extended/shorted so that the actual cycle time matches the cycle time defined for the program.
 
 ## Switching Programs
 A program switch can occur only at the start of the stage defined in `switch`.
-The current and target programs must have compatibel signal states at the switch point.
 
-It's allowed to switch between programs using different control strategies.
+It's allowed to switch between programs using different control strategies. But whether you switch to a program with the same or different control strategy, the current and target programs must have compatible signal states at the switch point.
 
-When a switch is requested the controller continues until the switch point, then continues from the switch point in the target program. When switching to a stage-based program,
-the progam continues from the start of the stage defined as the switch point.
+When a switch is requested the controller continues until the switch point, then continues from the switch point in the target program. When switching to a stage-based program, the progam continues from the start of the stage defined as the switch point.
 
-Once the program has changed, a new target offset is determined and the offset is gradually moved to the target, using the mechanism defined for the type of strategy of the target program.
+Once the program has switched, a new target offset is determined and the offset is gradually moved to the target, using the mechanism defined for the type of strategy of the target program.
 
 ## Failures
 The controller must respect all safety constraints (minimum green, intergreen, etc.). Invalid configurations or unsafe transitions result in a fault.

--- a/stage-based.md
+++ b/stage-based.md
@@ -14,44 +14,150 @@ Controllers must use UTC [synchronized](synchronization.md) using NTP.
 A stage-based program has the following structure:
 
 ```yaml
-cycle: 60
-offset: 0
 groups: ["a1", "a2", "b1", "b2", "a1_l"]
 stages:
   main:
     open: ["a1", "a2"]
     duration: { default: 20, max: 29}
-    transitions:
-      side: { 0: "11000", 3: "00220", 5: null }
-      turn: { 0: "11000", 3: null }
   side:
     open: ["b1", "b2"]
     duration: { min: 10, default: 20, max: 26}
-    transitions:
-      turn: { 0: "11000", 3: null }
   turn:
     open: ["a1_l"]
     duration: { default: 10}
-    transitions:
-      main: { 0: "11000", 3: null }
+transitions:
+  standby:
+    main:       ["00000", 2, "11000", 4, "AA000", 6]   # startup sequence
+  main:
+    side:
+      default:  ["11000", 3, "00220", 2]
+      busy:     ["11000", 5, "00220", 4]
+    turn:       ["11000", 3]
+  side:
+    turn:
+      default:  ["11000", 3]
+      busy:     ["11000", 5]
+    standby:    ["AA000", 2, "11000", 4, "00000", 6]   # shutdown sequence
+  turn:
+    main:       ["11000", 3]
+  fault:
+    standby:    ["00000", 2, "BBBBB", 4]   # fault sequence
+programs:
+  quiet:
+    main: ["side, "turn"]
+    side: ["turn"]
+    turn: ["main"]
+  busy:
+    main: ["side/busy"]
+    side: ["main", "main/busy"]
+  event:
+    main: ["turn"]
+    turn: ["main"]
 ```
 
-- **cycle**: Cycle time
-- **offset**: Default offset
-- **groups**: List of all signal groups
-- **stages**: Map of stages with stage name and options:
+- **cycle**: Cycle time.
+- **offset**: Default offset.
+- **groups**: List of all signal groups.
+- **standby**: Standby states of all groups.
+- **stages**: Stages by name.
+- **transition**: Transitions by source stage.
+- **programs**: Programs by name.
+
+### Stages
+Each stage is defined by which groups are open and for how long. All other groups must be closed.
+Open typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bar for public transport.
+
+All groups remain in the same state throughout the stage. All state changes happen during transitions.
+
+You can define how much the stage can be shortened or extended by setting `min` and/or `max` durations.
+
+A stage is defined as a map with:
   - `open`: List of signal groups that are open (typically green).
   - `duration`: Durations in seconds. `default` is required, while `min` and `max` are optional and specify possible shortening and extension.
-  - `transitions`: Possible transitions. The key is the name of the stage to transition to, while the value is a transition map.
 
-A transition map defines all state changes during a transition:
-  - keys: Transition time in seconds, measured from the start of the transition.
-  - values: A string containing the state of all signal groups, with one character for each group, in the order defined in the 'groups' attribute.
+### Transitions
+A transition defines how to move from one stage to another by explicitly listing all state changes, including intermediate states like yellow.
 
-Transition maps must include one element with the time set to 0, representing the start of the transition.
-Transition maps must include one element with the value set to null/nil, which indicates the end of the transition. No item can have times later than the end.
+A transition does not include the start and end states, as these are defined by the stages you come from and go to.
 
-In the program above, going through stages main-side-turn can be visualized as:
+A particular transition always goes through the same state changes with the same duration.
+
+If a transition between stages A and B is not defined, the program cannot transition directly from A to B, although it might be possible to reach B via other stages.
+
+When designing a stage-based program, it must be ensured that all transitions are valid.
+
+
+A transition is defined by a source/destination stage pair. The destination can be a transition array:
+
+```yaml
+  main:
+    side: ["11000", 3, "00220", 2]
+```
+
+Or another map if you want to define different transitions for the same source/destination pair:
+
+```yaml
+  main:
+    side:
+      default:  ["11000", 3, "00220", 2]
+      busy:     ["11000", 5, "00220", 4]
+```
+
+The transition array must have even number of elements. It starts with a state string followed by a duration, and then repeat this:
+
+```yaml
+ ["11000", 2, "00220", 4]
+```
+
+Here a1 and a2 groups are in state "1" for 5s, then b1 and b2 are in state "2" for 7 seconds.
+
+### Programs
+A program is defined by which stages and transitions be be used.
+It's defined as a map of source/transtions, with transitions  listed using an array of strings, e.g:
+
+```yaml
+    main: ["side, "turn"]
+    side: ["turn"]
+    turn: ["main"]
+```
+
+Here the the controller can go from the main stage to either the side or the turn stage.
+From side it can go only to side, and from turn it can go only to main.
+
+In case different transitions are defined for the same source/destination stage pair,
+slashes are used, e.g.:
+
+```yaml
+    side: ["main", "main/busy"]
+```
+
+Note: No logic is yet defined for how to choose which transition to use. This will be expanded later.
+
+## Startup and shutdown
+THe stage name `standby` has a special meaning. A stage with this name cannot be defined,
+but can be referenced in transitions
+
+One transition from the `standby` stage mus be defined, and is the startup sequence.
+One transition to the `standby` stage mus be defined, and is the shutdown sequence.
+
+When the controller powers up, it will start in the standby stage, and groups will be in the
+standby state, which is part of the intersection config, not the program.
+
+Example:
+
+```yaml
+transitions:
+  standby:
+    main:       ["00000", 2, "11000", 4, "AA000", 6]   # startup sequence
+  side:
+    standby:    ["AA000", 2, "11000", 4, "00000", 6]   # shutdown sequence
+```
+
+Here, after power up, the controller will transition into the `main` stage.
+Shutting down will happen after the `side` stage.
+
+## Example
+For the program shown at the top, going through the stages main-side-turn can be visualized as:
 
 ```
 stage  |main              |      |side             |   |turn    |   |
@@ -63,26 +169,6 @@ a1_l   |                  |      |                 |   |AAAAAAAA|111|
 switch |*                 |      |                 |   |        |   |
        0s                                                           60s
 ```
-
-## Stages
-Each stage is defined by which groups are open and for how long. All other groups must be closed.
-
-Open typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bar for public transport.
-
-All groups remain in the same state throughout the stage. All state changes happen during transitions.
-
-You can define how much the stage can be shortened or extended by setting `min` and/or `max` durations.
-
-## Transitions
-A transition defines how to move from one stage to another by explicitly listing all state changes, including intermediate states like yellow.
-
-A transition does not include the start and end states, as these are defined by the stages you come from and go to.
-
-A particular transition always goes through the same state changes with the same duration.
-
-If a transition between stages A and B is not defined, the program cannot transition directly from A to B, although it might be possible to reach B via other stages.
-
-When designing a stage-based program, it must be ensured that all transitions are valid.
 
 ## Changing Offset
 Intersections that use the same cycle length can be coordinated by modifying their offsets. But a change in offset can happen for other reasons, e.g.:
@@ -120,6 +206,19 @@ When a switch is requested the controller continues until the switch point, then
 
 Once the program has switched, a new target offset is determined and the offset is gradually moved to the target, using the mechanism defined for the type of strategy of the target program.
 
-## Failures
+## Faults
 The controller must respect all safety constraints (minimum green, intergreen, etc.). Invalid configurations or unsafe transitions result in a fault.
 Programs should be validated using a simulator or test tool before deployment.
+
+If a fault occurs, the controller immediately runs the fault to standby transition.
+If the transition foes goes to the `fault` stage the controller goes into the standby state.
+
+If another stage is specified, it continues with that stage.
+
+```yaml
+transitions:
+  fault:
+    standby:    ["00000", 2, "BBBBB", 4]   # fault sequence
+```
+
+If no fault transition is defined, the controller immedately goes to the standby state in case of a fault.

--- a/stage-based.md
+++ b/stage-based.md
@@ -1,0 +1,123 @@
+# Stage-based Strategy
+A stage-based program consists of stages separated by transitions.
+
+## Prerequisites
+Running a stage-based program depends on regional, controller, and intersection [configurations](configurations.md), which are defined outside the signal program.
+
+Specifically, signal groups and the conflict matrix are defined in the intersection configuration, not in the signal program.
+
+Similarly, regional settings like red-yellow time are defined in the regional/controller/intersection configuration, not in the signal program.
+
+Controllers must use UTC [synchronized](synchronization.md) using NTP.
+
+## Structure
+A stage-based program has the following structure:
+
+```yaml
+cycle: 60
+offset: 0
+groups: ["a1", "a2", "b1", "b2", "a1_l"]
+stages:
+  main:
+    open: ["a1", "a2"]
+    duration: { default: 20, max: 29}
+    transitions:
+      side: { 0: "11000", 3: "00220", 5: nil }
+      turn: { 0: "11000", 3: nil }
+  side:
+    open: ["b1", "b2"]
+    duration: { min: 10, default: 20, max: 26}
+    transitions:
+      turn: { 0: "11000", 3: nil }
+  turn:
+    open: ["a1_l"]
+    duration: { default: 10}
+    transitions:
+      main: { 0: "11000", 3: nil }
+```
+
+- **cycle**: Cycle time
+- **offset**: Default offset
+- **groups**: List of all signal groups
+- **stages**: Map of stages with stage name and options:
+  - `open`: List of signal groups that are open (green).
+  - `duration`: Durations in seconds. `default` is required, while `min` and `max` are optional and specify possible shortening and extension.
+  - `transitions`: Possible transitions. The key is the name of the stage to transition to, while the value is a transition map.
+
+A transition map define all state changes during the transation:
+  - keys: The transition time in seconds, measuring from the start of the transition. The first item must hve time 0.
+  - values: A string containing the state of all signal groups, with a character for each group, in the order defined in the 'groups' attribute.
+
+Transition maps must include one element with the value `nil`, whicb indicates the end (and thus the duration) of the transition. No other item can have a later time.
+
+
+In the program above, the `main` stage can transtion to either `side` or `turn`. Going through stages main-side-turn can be visualized as:
+
+```
+stage  |main              |      |side             |   |turn    |   |
+a1     |AAAAAAAAAAAAAAAAAA|111   |                 |   |        |   |
+a2     |AAAAAAAAAAAAAAAAAA|111   |                 |   |        |   |
+b1     |                  |   222|AAAAAAAAAAAAAAAAA|111|        |   |
+b2     |                  |   222|AAAAAAAAAAAAAAAAA|111|        |   |
+a1_l   |                  |      |                 |   |AAAAAAAA|111|
+switch |*                 |      |                 |   |        |   |
+       0s                                                           60s
+```
+
+## Stages
+Each stage is defined by which groups are open and for how long. All other groups will be closed.
+
+Open typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bar for public transport.
+
+All groups remain in the same state throughout the stage. All state changes happen during interstages.
+
+You can define how much the stage can be shortened or extended, which will be used by the controller to adjust stage durations to ensure that the cycle time is respected.
+The controller will also extend and shorten stages when the offset needs to be moved.
+
+A transition defines hwo to move from one stage to another, by explicitely listing all states changes, including intermediate states like yellow.
+A transition does not include the start or end states, as these are defined by the stages you come from and go to.
+
+A particular transition always goes through the same state changes and always has the same duration.
+
+If a transition between stagess A and B is not defined, the program cannot transition directly from A to B, alhough it might be possible to reach B via other stages.
+
+When designing a stage-based program, it must be ensured that all transitions are valid.
+
+## Changing Offset
+Intersections that use the same cycle length can be coordinated by modifying the offsets. But a change in offset can happen for other reasons, e.g.:
+
+- manual change of the offset
+- change between signal programs
+- synchronization of the underlying UTC time
+- leap seconds
+
+However, the offset cannot simply be abruptly changed, as this might cause invalid state changes, or might violate constraints like minimum or inter-green times.
+Instead the offset must be moved by shortening of extending stages. Since all groups remain in the same state during a stage, this is guaranteed to never cause invalid state changes.
+
+### Extending and Shortening Stages
+To change the offset, stages must be shortened or extended. Shortening stages will move the offset forward, while extending stages will move the backward.
+
+Since the program is cyclic, reaching the target offset can be achieved either by shorting or extending stages. The fastest way should be chosen.
+
+Only stages with `min` set can be shortened, and only stages with `max`set can be extended.
+
+Stages with neither `min`nor `max` are fixed in duration. If no `min`or `max` is set for any stage, the offset cannot be moved, and the controller cannot be coordinated with other controllers.
+
+When trying to reach the taget offset, shortering/extending is done oen stage at a time, while respecting the min/max durations.  Reaching the target offset might take more than one cycle, depending on the min/max values defined.
+
+Once the target offset is reached, the controller must adjust stage durations to ensure that the cycle time matches the value defined in the program, taking into account the interstage durations.
+
+## Switching Programs
+A program switch can occur only at the start of the stage defined in `switch`.
+The current and target programs must have compatibel signal states at the switch point.
+
+It's allowed to switch between programs using different control strategies.
+
+When a switch is requested the controller continues until the switch point, then continues from the switch point in the target program. When switching to a stage-based program,
+the progam continues from the start of the stage defined as the switch point.
+
+Once the program has changed, a new target offset is determined and the offset is gradually moved to the target, using the mechanism defined for the type of strategy of the target program.
+
+## Failures
+The controller must respect all safety constraints (minimum green, intergreen, etc.). Invalid configurations or unsafe transitions result in a fault.
+Programs should be validated using a simulator or test tool before deployment.

--- a/stage-based.md
+++ b/stage-based.md
@@ -1,5 +1,5 @@
 # Stage-based Strategy
-A stage-based program consists of stages separated by transitions. All state changes occur during transitions, while state state remain static during stages.
+A stage-based program consists of stages separated by transitions. All state changes occur during transitions, while state remain static during stages.
 
 ## Prerequisites
 Running a stage-based program depends on regional, controller, and intersection [configurations](configurations.md), which are defined outside the signal program.
@@ -44,12 +44,12 @@ stages:
   - `duration`: Durations in seconds. `default` is required, while `min` and `max` are optional and specify possible shortening and extension.
   - `transitions`: Possible transitions. The key is the name of the stage to transition to, while the value is a transition map.
 
-A transition map define all state changes during a transation:
+A transition map defines all state changes during a transition:
   - keys: Transition time in seconds, measured from the start of the transition.
   - values: A string containing the state of all signal groups, with one character for each group, in the order defined in the 'groups' attribute.
 
-Transition maps msut include one element with the tiem set to 0, representing the start of the transition.
-Transition maps must include one element with the value set to null/nil, which indicates the end of the transition. No  item can have times later than the end.
+Transition maps must include one element with the time set to 0, representing the start of the transition.
+Transition maps must include one element with the value set to null/nil, which indicates the end of the transition. No item can have times later than the end.
 
 In the program above, going through stages main-side-turn can be visualized as:
 
@@ -74,13 +74,13 @@ All groups remain in the same state throughout the stage. All state changes happ
 You can define how much the stage can be shortened or extended by setting `min` and/or `max` durations.
 
 ## Transitions
-A transition defines how to move from one stage to another by explicitely listing all states changes, including intermediate states like yellow.
+A transition defines how to move from one stage to another by explicitly listing all state changes, including intermediate states like yellow.
 
 A transition does not include the start and end states, as these are defined by the stages you come from and go to.
 
-Transitions a fiex and goes through the same state changes every time, with the same duration.
+A particular transition always goes through the same state changes with the same duration.
 
-If a transition between stagess A and B is not defined, the program cannot transition directly from A to B, alhough it might be possible to reach B via other stages.
+If a transition between stages A and B is not defined, the program cannot transition directly from A to B, although it might be possible to reach B via other stages.
 
 When designing a stage-based program, it must be ensured that all transitions are valid.
 
@@ -94,12 +94,12 @@ Intersections that use the same cycle length can be coordinated by modifying the
 
 However, the offset cannot be changed abruptly, as this might cause invalid state changes or might violate constraints like minimum or intergreen times.
 
-Instead the offset must be moved by shortening or/ extending stages. Since all groups remain in the same state during a stage, this is guaranteed to never cause invalid state changes.
+Instead the offset must be moved by shortening or extending stages. Since all groups remain in the same state during a stage, this is guaranteed to never cause invalid state changes.
 
 ### Extending and Shortening Stages
 Shortening stages will move the offset forward, while extending stages will move it backward.
 
-Since the program is cyclic, reaching the target offset can be achieved either by shorting or extending stages. The quickest way should be chosen.
+Since the program is cyclic, reaching the target offset can be achieved either by shortening or extending stages. The quickest way should be chosen.
 
 Only stages with `min` defined can be shortened and only stages with `max` defined can be extended.
 
@@ -109,14 +109,14 @@ When trying to reach the target offset, shortening/extending is done one stage a
 
 Once the target offset is reached, the controller must adjust stage durations to ensure that the actual cycle time matches the cycle time defined in the program, taking into account the transition durations.
 
-A program is invalid if the stages cannot be extended/shorted so that the actual cycle time matches the cycle time defined for the program.
+A program is invalid if the stages cannot be extended/shortened so that the actual cycle time matches the cycle time defined for the program.
 
 ## Switching Programs
 A program switch can occur only at the start of the stage defined in `switch`.
 
 It's allowed to switch between programs using different control strategies. But whether you switch to a program with the same or different control strategy, the current and target programs must have compatible signal states at the switch point.
 
-When a switch is requested the controller continues until the switch point, then continues from the switch point in the target program. When switching to a stage-based program, the progam continues from the start of the stage defined as the switch point.
+When a switch is requested the controller continues until the switch point, then continues from the switch point in the target program. When switching to a stage-based program, the program continues from the start of the stage defined as the switch point.
 
 Once the program has switched, a new target offset is determined and the offset is gradually moved to the target, using the mechanism defined for the type of strategy of the target program.
 

--- a/stage-based.md
+++ b/stage-based.md
@@ -11,7 +11,10 @@ Similarly, regional settings like red-yellow time are defined in the regional/co
 Controllers must use UTC [synchronized](synchronization.md) using NTP.
 
 ## Structure
-Stage-based programs first define stages and transitions, which are shared between programs:
+Stage-based programs first define stages and transitions.
+Program are then defines by which stages are used, the flow between stages and where you enter and leave the program.
+
+The stage names "enter" and "leave" are reserved and cannot be used when defining stages.
 
 ```yaml
 groups: ["a1", "a2", "b1", "b2", "a1_l"]
@@ -33,184 +36,29 @@ transitions:
       default:  ["11000", 3, "00220", 2]
       quick:    ["11000", 5, "00220", 4]
     turn:       ["11002", 3]
-    oneway:     ["11000", 3]
   side:
     turn:
       default:  ["11000", 5]
       quick:    ["11000", 3]
   turn:
     main:       ["11000", 3]
-  oneway:
-    main:       ["00110", 4]
+programs:
+  quiet:
+    enter: {main:}
+    main:  {side:, turn:}
+    side:  {turn:}
+    turn:  {main:, leave:}
+  busy:
+    enter: {side:}
+    side:  {main: quick}
+    main:  {side: quick, leave: quick}
+  event:
+    enter: {side:}
+    side:  {turn:, :leave}
+    turn:  {side:}
 ```
 
-A program defines the stages and possible transitions, as well as how you can enter and leave the program.
-
-Here a program for quiet periods:
-
-```yaml
-name: quiet
-flow:
-  main:
-    side:
-    turn:
-  side:
-    turn:
-  turn:
-    main:
-enter:
-  main:
-leave:
-  side:
-```
-
-A program for busy periods:
-```yaml
-name: busy
-flow:
-  main:
-    side: { using: quick }
-  side:
-    main: { using: quick }
-enter:
-  side:
-leave:
-  main:
-    side: { using: quick }
-```
-
-
-A program for a special event:
-```yaml
-name: event
-flow:
-  oneway:
-enter:
-  main:
-    oneway:
-leave:
-  oneway:
-    main:
-```
-
-### Stages
-Each stage is defined by which groups are open and for how long. All other groups must be closed.
-Open typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bar for public transport.
-
-All groups remain in the same state throughout the stage. All state changes happen during transitions.
-
-You can define how much the stage can be shortened or extended by setting `min` and/or `max` durations.
-
-A stage is defined as a map with:
-  - `open`: List of signal groups that are open (typically green).
-  - `duration`: Durations in seconds. `default` is required, while `min` and `max` are optional and specify possible shortening and extension.
-  - `switch`: True if program switch can happen at the beginning of this stage.
-
-### Transitions
-A transition defines how to move from one stage to another by explicitly listing all state changes, including intermediate states like yellow.
-
-A transition does not include the start and end states, as these are defined by the stages you come from and go to.
-
-A particular transition always goes through the same state changes with the same duration.
-
-If a transition between stages A and B is not defined, the program cannot transition directly from A to B, although it might be possible to reach B via other stages.
-
-When designing a stage-based program, it must be ensured that all transitions are valid.
-
-
-A transition is defined by a source/destination stage pair. The destination can be a transition array:
-
-```yaml
-  main:
-    side: ["11000", 3, "00220", 2]
-```
-
-Or another map if you want to define different transitions for the same source/destination pair:
-
-```yaml
-  main:
-    side:
-      default:  ["11000", 3, "00220", 2]
-      busy:     ["11000", 5, "00220", 4]
-```
-
-The transition array must have even number of elements. It starts with a state string followed by a duration, and then repeat this:
-
-```yaml
- ["11000", 2, "00220", 4]
-```
-
-Here a1 and a2 groups are in state "1" for 5s, then b1 and b2 are in state "2" for 7 seconds.
-
-### Programs
-A program is defined by which stages and transitions be be used.
-It's defined as a map of source/transtions, with transitions  listed using an array of strings, e.g:
-
-```yaml
-flow:
-  main:
-    side:
-    turn:
-  side:
-    turn:
-  turn:
-    main:
-```
-
-Here the the controller can go from the main stage to either the side or the turn stage.
-From side it can go only to side, and from turn it can go only to main.
-
-In case different transitions are defined for the same source/destination stage pair,
-the variant is specified with 'using':
-
-```yaml
-  main:
-    side: { using: quick }
-```
-
-Note: No logic is yet defined for how to choose which transition to use. This will be expanded later.
-
-## Switching Programs
-A program switch can occur at a stage that's present in both the origin and destination programs.
-
-Switch stages are specified as:
-```yaml
-enter:
-  main:
-leave:
-  side:
-```
-
-If you need to switch to a program that does not share any stages, you can istead use a transition:
-
-```yaml
-enter:
-  main:
-    oneway:
-leave:
-  oneway:
-    main:
-```yaml
-
-In this example, the transitions between main and oneway stages are not used in the normal flow of the program, but can be used to switch to a program that has uses the main stage.
-
-You can specify a transition variant if needed:
-
-```yaml
-leave:
-  main:
-    side: { using: quick }
-```
-
-
-It's allowed to switch between programs using different control strategies. But whether you switch to a program with the same or different control strategy, the two programs must have compatible signal states at the switch point. This mean there must be a stage with matching states. This state does not have be be used in the normal flow of any stage-based program, but can be used just in enter/leave definitions.
-
-When a switch is requested the controller continues until the switch point, then continues from the switch point in the target program.
-
-Once the program has switched, a new target offset is determined and the offset is gradually moved to the target, using the mechanism defined for the type of strategy of the target program.
-
-## Example
-For the program shown at the top, going through the stages main-side-turn can be visualized as:
+The `quiet` program going through the stages main-side-turn can be visualized as:
 
 ```
 stage  |main              |      |side             |   |turn    |   |
@@ -223,6 +71,139 @@ switch |*                 |      |                 |   |        |   |
        0s                                                           60s
 ```
 
+## Stages
+Each stage is defined by which groups are open and for how long. All other groups must be closed.
+Open typically means green, while closed typically means red. But depending on the type of group it could be e.g. a white horizontal or vertical bar for public transport.
+
+All groups remain in the same state throughout the stage. All state changes happen during transitions.
+
+You can define how much the stage can be shortened or extended by setting `min` and/or `max` durations.
+
+Example:
+
+```yaml
+stages:
+  main:                                # stage name
+    open: ["a1", "a2"]                 # list of groups
+    duration: { default: 20, max: 29 } # duration settings
+```
+- `open`: List of signal groups that are open (typically green).
+- `duration`: Durations in seconds. `default` is required, while `min` and `max` are optional and specify possible shortening and extension.
+
+## Transitions
+A transition defines how to move from one stage to another by explicitly listing all state changes, including intermediate states like yellow.
+
+A transition does not include the start and end states, as these are defined by the stages you come from and go to.
+
+A  transition always goes through the same state changes with the same duration.
+
+If a transition between stages A and B is not defined, the program cannot transition directly from A to B, although it might be possible to reach B via other stages.
+
+When designing a stage-based program, it must be ensured that all transitions are valid.
+
+You can define a single transition between two stages, by setting the value of the <to stage> to a sequence:
+
+```yaml
+  <from stage>:
+    <to stage>: [<transition sequence>]
+```
+
+Example:
+
+```yaml
+  main:
+    side: ["11000", 3, "00220", 2]
+```
+
+Or you can define multiple transitions between the two stage by using a map:
+
+```yaml
+  <from stage>:
+    <to stage>:
+      <transition name>: [<transition sequence>]
+      <transition name>: [<transition sequence>]
+```
+
+Example:
+
+```yaml
+  main:
+    side:
+      default:  ["11000", 3, "00220", 2]
+      busy:     ["11000", 5, "00220", 4]
+```
+
+The transition name `default` is special. If you define multiple transitions between two stages and refer to a transition bewtween within using a transition name, the `default` transition must be defined and will then be used.
+
+Transition sequences are defined as an array with an even number of elements. It starts with a state string followed by a duration, and then repeat these pairs. It can have 0, 1 or more state/duration pairs. Each character refers to a group listed in `groups` defined earlier.
+
+## Programs
+A program is defined by which stages and transitions be be used.
+It's defined as a map of source/transtions, with transitions  listed using an array of strings, e.g:
+
+```yaml
+programs:
+  <program name>:
+    <from stage>:
+      <to stage>: <optional transtion name>
+```
+The stage names `enter` and `leave` are special, and used to indicate where you can enter or leave the program, i.e. switch between programs.
+
+Example:
+```yaml
+programs:
+  quiet:
+    enter: {main:}
+    main:  {side:, turn:}
+    side:  {turn:}
+    turn:  {main:, leave:}
+```
+
+Here the the controller can enter the program at the main stage. From the main stage it can go to either the side or the turn stage.
+From side it can go only to side, and from turn it can go only to main. It can leave from the side stage.
+
+In case different transitions are defined for the same source/destination stage pair a variant can specified. If not specied,
+the default transition will be used:
+
+```yaml
+  busy:
+    side:
+      main: quick     # when going from side to main, use the quick transition.
+```
+
+Note: No logic is yet defined for how to choose which transition to use. This will be expanded later.
+
+## Switching Programs
+A program switch can occur at stages that are marked for either entering or leaving, usign the special stage names `enter` and `leave`:
+
+```yaml
+    enter: {main:}
+    main:  {leave:}
+```
+### Direct switch
+If program A allows leaving from the `main` stage, and program B allows entering into the same `main` stage, then a switch from A to B can happend directy as soon as the main stage is reached.
+
+### Transition switch
+If program A allows leaving from the `main` stage, but program B allows entering only to a different stage like `side`, then a transition from the `main` stage to the `side` stage must be defined for a switch to be possible. If more than one transition between the two stages are defined you can specify which one is used:
+
+```yaml
+    enter: {main:}
+    main:
+      leave: quick
+```
+
+## Switching between program with different control strategies
+It's allowed to switch between programs using different control strategies. But whether you switch to a program with the same or different control strategy, the two programs must have compatible signal states at the switch point. 
+For stage-based program the switch points are the stages are maked for entering/leaving. The states is defined by the stages themselves, i.e. which grous are open/closed.
+
+```yaml
+groups: ["a1", "a2", "b1", "b2", "a1_l"]
+stages:
+  main:
+    open: ["a1", "a2"]
+
+For example, the main stage has groups a1 and a2 open, and all other groups closed, corresponding to the state "11000". You can switch to/from another type of program, e.g. a fixed time program, if it defines a switch points with the same state.
+
 ## Changing Offset
 Intersections that use the same cycle length can be coordinated by modifying their offsets. But a change in offset can happen for other reasons, e.g.:
 
@@ -233,7 +214,9 @@ Intersections that use the same cycle length can be coordinated by modifying the
 
 However, the offset cannot be changed abruptly, as this might cause invalid state changes or might violate constraints like minimum or intergreen times.
 
-Instead the offset must be moved by shortening or extending stages. Since all groups remain in the same state during a stage, this is guaranteed to never cause invalid state changes.
+Instead the offset must be moved gradually by shortening or extending stages. Since all groups remain in the same state during a stage, this is guaranteed to never cause invalid state changes.
+
+Once the target offset is reached, cycle time must be kept constant, to ensure coordination is kept.
 
 ### Extending and Shortening Stages
 Shortening stages will move the offset forward, while extending stages will move it backward.

--- a/stage-based.md
+++ b/stage-based.md
@@ -215,8 +215,9 @@ groups: ["a1", "a2", "b1", "b2", "a1_l"]
 stages:
   main:
     open: ["a1", "a2"]
+```
 
-For example, the main stage has groups a1 and a2 open, and all other groups closed, corresponding to the state "11000". You can switch to/from another type of program, e.g. a fixed time program, if it defines a switch points with the same state.
+For example, the main stage has groups a1 and a2 open and all other groups closed, corresponding to the state "11000". You can switch to/from another type of program, e.g. a fixed time program, if it defines a switch points with the same state.
 
 ## Changing Offset
 Intersections that use the same cycle length can be coordinated by modifying their offsets. But a change in offset can happen for other reasons, e.g.:

--- a/stage-based.md
+++ b/stage-based.md
@@ -58,7 +58,7 @@ programs:
     turn:  {side:}
 ```
 
-The `quiet` program going through the stages main-side-turn can be visualized as:
+The `quiet` program going through the stages main-side-turn can be visualized as a timeline:
 
 ```
 stage  |main              |      |side             |   |turn    |   |
@@ -69,6 +69,19 @@ b2     |                  |   222|AAAAAAAAAAAAAAAAA|111|        |   |
 a1_l   |                  |      |                 |   |AAAAAAAA|111|
 switch |*                 |      |                 |   |        |   |
        0s                                                           60s
+```
+
+Or as a stage diagram:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> main
+    main --> side
+    main --> turn
+    side --> turn
+    turn --> main
+    turn --> [*]
 ```
 
 ## Stages
@@ -177,8 +190,10 @@ Note: No logic is yet defined for how to choose which transition to use. This wi
 A program switch can occur at stages that are marked for either entering or leaving, usign the special stage names `enter` and `leave`:
 
 ```yaml
-    enter: {main:}
-    main:  {leave:}
+    enter:
+      main:
+    main:
+      leave:
 ```
 ### Direct switch
 If program A allows leaving from the `main` stage, and program B allows entering into the same `main` stage, then a switch from A to B can happend directy as soon as the main stage is reached.
@@ -187,7 +202,8 @@ If program A allows leaving from the `main` stage, and program B allows entering
 If program A allows leaving from the `main` stage, but program B allows entering only to a different stage like `side`, then a transition from the `main` stage to the `side` stage must be defined for a switch to be possible. If more than one transition between the two stages are defined you can specify which one is used:
 
 ```yaml
-    enter: {main:}
+    enter:
+      main:
     main:
       leave: quick
 ```

--- a/stage-based.md
+++ b/stage-based.md
@@ -22,18 +22,18 @@ stages:
     open: ["a1", "a2"]
     duration: { default: 20, max: 29}
     transitions:
-      side: { 0: "11000", 3: "00220", 5: nil }
-      turn: { 0: "11000", 3: nil }
+      side: { 0: "11000", 3: "00220", 5: null }
+      turn: { 0: "11000", 3: null }
   side:
     open: ["b1", "b2"]
     duration: { min: 10, default: 20, max: 26}
     transitions:
-      turn: { 0: "11000", 3: nil }
+      turn: { 0: "11000", 3: null }
   turn:
     open: ["a1_l"]
     duration: { default: 10}
     transitions:
-      main: { 0: "11000", 3: nil }
+      main: { 0: "11000", 3: null }
 ```
 
 - **cycle**: Cycle time
@@ -48,7 +48,7 @@ A transition map define all state changes during the transation:
   - keys: The transition time in seconds, measuring from the start of the transition. The first item must hve time 0.
   - values: A string containing the state of all signal groups, with a character for each group, in the order defined in the 'groups' attribute.
 
-Transition maps must include one element with the value `nil`, whicb indicates the end (and thus the duration) of the transition. No other item can have a later time.
+Transition maps must include one element with the value set to null/nil, whicb indicates the end (and thus the duration) of the transition. No other item can have a later time.
 
 
 In the program above, the `main` stage can transtion to either `side` or `turn`. Going through stages main-side-turn can be visualized as:

--- a/stage-based.md
+++ b/stage-based.md
@@ -1,6 +1,17 @@
 # Stage-based Strategy
 A stage-based program consists of stages separated by transitions. All state changes occur during transitions, while state remain static during stages.
 
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> main
+    main --> side
+    main --> turn
+    side --> turn
+    turn --> main
+    turn --> [*]
+```
+
 ## Prerequisites
 Running a stage-based program depends on regional, controller, and intersection [configurations](configurations.md), which are defined outside the signal program.
 
@@ -58,7 +69,7 @@ programs:
     turn:  {side:}
 ```
 
-The `quiet` program going through the stages main-side-turn can be visualized as a timeline:
+The `quiet` program going through the stages main-side-turn might produce this output:
 
 ```
 stage  |main              |      |side             |   |turn    |   |
@@ -69,19 +80,6 @@ b2     |                  |   222|AAAAAAAAAAAAAAAAA|111|        |   |
 a1_l   |                  |      |                 |   |AAAAAAAA|111|
 switch |*                 |      |                 |   |        |   |
        0s                                                           60s
-```
-
-Or as a stage diagram:
-
-```mermaid
-stateDiagram-v2
-    direction LR
-    [*] --> main
-    main --> side
-    main --> turn
-    side --> turn
-    turn --> main
-    turn --> [*]
 ```
 
 ## Stages


### PR DESCRIPTION
Add stage-based strategy, where transitions are explicitly defined. Replaces PR #32, where transitions where determined at run-time by the controller.


You still have an offset for coordination, but perhaps this should be optional in case you would rather give the controller freedom to shuffle stages more freely.

Switching program might require more consideration.

No logic or behaviour is yet defined for how to choose which stages to transition to, if more than one possible transition is defined.

A this point we're not yet considering sensor actuation.


